### PR TITLE
Remove id field from ContactBuilder class to rely on MySQL auto-generation.

### DIFF
--- a/src/main/java/com/jaberrantisi/contactmanager/model/Contact.java
+++ b/src/main/java/com/jaberrantisi/contactmanager/model/Contact.java
@@ -113,7 +113,6 @@ public class Contact {
 
     public static class ContactBuilder {
 
-        private Long id;
 
         private String firstName;
 

--- a/src/main/java/com/jaberrantisi/contactmanager/model/Contact.java
+++ b/src/main/java/com/jaberrantisi/contactmanager/model/Contact.java
@@ -113,11 +113,9 @@ public class Contact {
 
     public static class ContactBuilder {
 
-
         private String firstName;
 
         private String lastName;
-
 
         private String phoneNumber;
 


### PR DESCRIPTION
Removed the id field from the ContactBuilder class.
The id field will now be auto-generated by MySQL.
Updated the code to ensure that the Contact object is properly handled with the database-generated ID.
No functional changes were made to the application logic, only to the ContactBuilder class.